### PR TITLE
[ApiCompat] Add list of specific paths to manifest

### DIFF
--- a/Tasks/ApiCompat/vss-extension.json
+++ b/Tasks/ApiCompat/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "binaries-comparer",
     "name": "Binaries Comparer",
-    "version": "0.1.3",
+    "version": "0.2.1",
     "publisher": "SOUTHWORKS",
     "targets": [
         {
@@ -34,30 +34,30 @@
         "uri": "https://github.com/southworkscom/SOUTHWORKS-azure-pipelines-tasks/tree/master/Tasks/ApiCompat"
     },
     "files": [
-        {
-            "path": "source/lib/"
-        },
 		{
-            "path": "source/ApiCompat/"
-        },
+			"path": "source/lib/"
+		},
 		{
-            "path": "source/node_modules/"
-        },
+			"path": "source/ApiCompat/"
+		},
 		{
-            "path": "source/.eslintrc.js"
-        },
+			"path": "source/node_modules/"
+		},
 		{
-            "path": "source/icon.png"
-        },
+			"path": "source/.eslintrc.js"
+		},
 		{
-            "path": "source/package.json"
-        },
+			"path": "source/icon.png"
+		},
 		{
-            "path": "source/task.json"
-        },
+			"path": "source/package.json"
+		},
 		{
-            "path": "source/tsconfig.json"
-        }
+			"path": "source/task.json"
+		},
+		{
+			"path": "source/tsconfig.json"
+		}
     ],
     "contributions": [
         {

--- a/Tasks/ApiCompat/vss-extension.json
+++ b/Tasks/ApiCompat/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "binaries-comparer",
     "name": "Binaries Comparer",
-    "version": "0.2.1",
+    "version": "0.1.3",
     "publisher": "SOUTHWORKS",
     "targets": [
         {
@@ -35,7 +35,28 @@
     },
     "files": [
         {
-            "path": "source"
+            "path": "source/lib/"
+        },
+		{
+            "path": "source/ApiCompat/"
+        },
+		{
+            "path": "source/node_modules/"
+        },
+		{
+            "path": "source/.eslintrc.js"
+        },
+		{
+            "path": "source/icon.png"
+        },
+		{
+            "path": "source/package.json"
+        },
+		{
+            "path": "source/task.json"
+        },
+		{
+            "path": "source/tsconfig.json"
         }
     ],
     "contributions": [


### PR DESCRIPTION
By adding a list of paths instead of a single path, the `.ts` and other files can be avoided to be included in the final `.vsix` file.