### PR TITLE
[GitHub PR Comment Task] Fix index.js not found issue.

### DIFF
--- a/Tasks/GitHubPRComment/githubComment/index.ts
+++ b/Tasks/GitHubPRComment/githubComment/index.ts
@@ -8,8 +8,6 @@ const clientWithAuth = new gitClient({
     userAgent: 'octokit/rest.js v1.2.3',
 });
 
-
-
 async function run() {
     var files = getFilesFromDir(taskLibrary.getInput('bodyFilePath'), '.' + taskLibrary.getInput('extension'), taskLibrary.getBoolInput('getSubFolders'))
     var message = combineMessageBody(files);
@@ -18,10 +16,10 @@ async function run() {
     const comment: gitClient.IssuesCreateCommentParams = {
         owner: repo[0],
         repo: repo[1],
-        issue_number: parseInt(taskLibrary.getInput('prNumber')),
+        number: parseInt(taskLibrary.getInput('prNumber')),
         body: "\r\n" + message + "\r\n"
     };
-    
+
     await clientWithAuth.issues.createComment(comment).then(res => {
         console.log(res);
     })
@@ -31,7 +29,6 @@ async function run() {
 }
 
 const getFilesFromDir = (filePath: string, extName: string, recursive: boolean): string[] => {
-    
     if (!fs.existsSync(filePath)){
         console.log("File path does not exist: ",filePath);
         return [];
@@ -55,7 +52,7 @@ const iterateFilesFromDir = (filePath: string, extName: string, recursive: boole
             result.push(fileName);
         } 
     });
-    
+
     return result;
 }
 

--- a/Tasks/GitHubPRComment/githubComment/package.json
+++ b/Tasks/GitHubPRComment/githubComment/package.json
@@ -17,7 +17,7 @@
   "author": "ParadoxArg",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^16.21.0",
+    "@octokit/rest": "16.21.0",
     "azure-pipelines-task-lib": "^2.8.0"
   },
   "devDependencies": {

--- a/Tasks/GitHubPRComment/githubComment/task.json
+++ b/Tasks/GitHubPRComment/githubComment/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 2
     },
     "instanceNameFormat": "GitHub Comment Publisher",
     "inputs": [

--- a/Tasks/GitHubPRComment/vss-extension.json
+++ b/Tasks/GitHubPRComment/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
      "id": "github-pr-comment",
      "name": "GitHub PR Comment",
-     "version": "0.1.0",
+     "version": "0.1.2",
      "publisher": "SOUTHWORKS",
      "targets": [
          {


### PR DESCRIPTION
Fixes #24

## Description
This PR fixes the 'index.js not found' issue when running the task in a pipeline.

### Detailed changes
-  **_index.ts_**: Updated param name in _IssuesCreateCommentParams_ method.
- **_package.json_**: Set @octokit/rest version to 16.21.0 to prevent breaking changes.
- **_task.json_** & **_vss-extension.json_**: Increased patch version number.