### PR TITLE
fix: [#27] GitHub PR Comment Task fails silently

### DIFF
--- a/Tasks/GitHubPRComment/githubComment/index.ts
+++ b/Tasks/GitHubPRComment/githubComment/index.ts
@@ -24,7 +24,7 @@ async function run() {
         console.log(res);
     })
     .catch(err => {
-        console.log(err);
+        taskLibrary.setResult(taskLibrary.TaskResult.Failed, err);
     });
 }
 

--- a/Tasks/GitHubPRComment/githubComment/task.json
+++ b/Tasks/GitHubPRComment/githubComment/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 3
     },
     "instanceNameFormat": "GitHub Comment Publisher",
     "inputs": [

--- a/Tasks/GitHubPRComment/vss-extension.json
+++ b/Tasks/GitHubPRComment/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
      "id": "github-pr-comment",
      "name": "GitHub PR Comment",
-     "version": "0.1.2",
+     "version": "0.1.3",
      "publisher": "SOUTHWORKS",
      "targets": [
          {


### PR DESCRIPTION
Fixes #27
#minor

## Description
This PR prevents the pipeline from running properly due to an error trying to comment on a PR.

## Specific Changes
- Updated index.ts to set the job to failed.

## Testing
Happy path (the job comments the PR)
![image](https://user-images.githubusercontent.com/64815358/169597854-9cc7f2fb-082b-49c8-bb51-29061108a926.png)

Incorrect token (the job fails)
![image](https://user-images.githubusercontent.com/64815358/169598247-2c51eee9-611a-4f11-a2ca-6cbc5f629acd.png)

