### PR TITLE
Update GitHubPRComment version

### DIFF
--- a/Tasks/GitHubPRComment/githubComment/task.json
+++ b/Tasks/GitHubPRComment/githubComment/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "GitHub Comment Publisher",
     "inputs": [

--- a/Tasks/GitHubPRComment/vss-extension.json
+++ b/Tasks/GitHubPRComment/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
      "id": "github-pr-comment",
      "name": "GitHub PR Comment",
-     "version": "0.2.3",
+     "version": "0.2.4",
      "publisher": "SOUTHWORKS",
      "targets": [
          {


### PR DESCRIPTION
## Description
This PR updates the GitHubPRComment version to 0.2.4 so that the updated documentation is displayed in the marketplace

## Specific Changes
- Version updated in _task.json_ and _vss-extension.json_ files.